### PR TITLE
fix(projection): allow equirectangular projection to be manually specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npm install stereo-img
   - `360`: Full sphere
 * `projection`: (Optional) hint at projection (most VR pictures use equirectangular projection)
   - If unset, projection is inferred from heuristics.
+  - `equirectangular`: Equirectangular projection
   - `fisheye`: Fisheye projection
 * `wiggle`: (Optional) When viewing in 2D, alternate between left and right images to help the user see the 3D effect
   - `enabled`: wiggle is enabled

--- a/parsers/stereo-parser/stereo-parser.js
+++ b/parsers/stereo-parser/stereo-parser.js
@@ -41,6 +41,8 @@ async function parseStereo(url, options) {
   let projection;
   if(options?.projection === 'fisheye') {
     projection = 'fisheye';
+  } else if(options?.projection === 'equirectangular') { 
+    ;
   } else {
     // Read pixels in each corner and middle to see if they are black. If black, assume fisheye image
     const topLeft = ctx.getImageData(0, 0, 1, 1).data;


### PR DESCRIPTION
In the current implementation, an equirectangular projected image with black dots in the corners for some reason is recognized as a fisheye image. This PR should resolve this problem.