### PR TITLE
Refactor: Rename 2D display attribute to display-2d

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ npm install stereo-img
   - If unset, projection is inferred from heuristics.
   - `equirectangular`: Equirectangular projection
   - `fisheye`: Fisheye projection
-* `wiggle`: (Optional) When viewing in 2D, alternate between left and right images to help the user see the 3D effect
-  - `enabled`: wiggle is enabled
-  - `disabled`: wiggle is disabled
+* `display-2d`: (Optional) Controls the display mode when not in VR. Defaults to `wiggle`.
+  - `static`: Displays a static image (left eye).
+  - `wiggle`: (Default) Alternates between left and right images to simulate a 3D effect.
+  - `anaglyph`: Displays the image in red-cyan anaglyph 3D (requires red-cyan glasses).
+* `wiggle`: (Deprecated) Use the `display-2d="wiggle"` attribute instead. When viewing in 2D, alternate between left and right images to help the user see the 3D effect.
+  - `enabled`: wiggle is enabled (equivalent to `display-2d="wiggle"`)
+  - `disabled`: wiggle is disabled (equivalent to `display-2d="static"`)
 
 ## Compatibility
 

--- a/index.html
+++ b/index.html
@@ -124,7 +124,13 @@ limitations under the License.
     <stereo-img src="examples/vr180-lenovo-mirage.vr.jpg" type="vr"></stereo-img>
     <button id="previous">Previous</button> <button id="next">Next</button> (or use left/right keyboard keys)
 
-    <p>These are best viewed in VR, click "Enter VR" if your device supports VR.</p>
+    <p>These are best viewed in VR, click "Enter VR" if your device supports VR. The default 2D mode is 'Wiggle'. You can also cycle through other 2D modes (Static, Anaglyph) using the button on the top-left of the image.</p>
+
+    <h3>Anaglyph Mode Example (defaulting to anaglyph)</h3>
+    <stereo-img src="examples/leia_lume_pad2.jpg" type="left-right" display-2d="anaglyph"></stereo-img>
+
+    <h3>Static Mode Example (defaulting to static)</h3>
+    <stereo-img src="examples/calf-left-right.jpg" type="left-right" display-2d="static"></stereo-img>
 
     <h2>Use it</h2>
 


### PR DESCRIPTION
Renamed the attribute for controlling 2D display modes from `2d` to `display-2d` to avoid potential issues with query selectors and improve clarity.

- Updated `stereo-img.js` to use `display-2d` for attribute getting/setting and internal logic.
- Updated `index.html` examples to use `display-2d`.
- Updated `README.md` documentation to reflect the new attribute name `display-2d`.

fix https://github.com/steren/stereo-img/issues/55