### PR TITLE
Fix alpha handling in anaglyph parser

### DIFF
--- a/parsers/anaglyph-parser/anaglyph-parser.js
+++ b/parsers/anaglyph-parser/anaglyph-parser.js
@@ -34,7 +34,7 @@ async function parseAnaglyph(url) {
   for (let i = 0; i < data.length; i += 4) {
     const r = data[i];
     const g = data[i + 1];
-    const a = data[i + 2];
+    const a = data[i + 3];
     leftEyePixels.push(r);
     leftEyePixels.push(r);
     leftEyePixels.push(r);


### PR DESCRIPTION
## Summary
- correct alpha channel extraction when parsing anaglyph images

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687de8acce0c8332b4edefe0c6fcd45d