### PR TITLE
Fix Dual Fisheye typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ This component has been manually tested to load pictures taken with the followin
 | Status | Camera                              | Picture type        | Attributes required                   |  Field of view | Orientation |
 | ------ | ----------------------------------- | ------------------- | ------------------------------------- | ------------- | ----------- |
 | ✔️     | Lenovo Mirage Camera                | VR180               | (none)                                |  ✓           | ✓ 
-| ✔️     | Canon RF5.2mm F2.8 L Duel Fisheye unprocessed | left-right fisheye           | (none)             |  X           | X 
-| ✔️     | Canon RF5.2mm F2.8 L Duel Fisheye processed with EOS VR Utility | left-right | (none)             |  X           | X 
+| ✔️     | Canon RF5.2mm F2.8 L Dual Fisheye unprocessed | left-right fisheye           | (none)             |  X           | X 
+| ✔️     | Canon RF5.2mm F2.8 L Dual Fisheye processed with EOS VR Utility | left-right | (none)             |  X           | X 
 | ✔️     | Insta360 Evo                        | left-right          | (none)                                |  X           | X 
 | ✔️     | CALF VR180                          | left-right          | (none)                                |  X           | X 
 | ✔️     | CALF VR180                          | "vr180"             | `angle="180"`                         |  X           | X 


### PR DESCRIPTION
## Summary
- fix Canon lens name in the camera support table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df705fbe88332a42086ec7d356601