### PR TITLE
Add tests for all parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "examples"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "npx serve"
   },
   "repository": {

--- a/parsers/depth-parser/depth-parser.js
+++ b/parsers/depth-parser/depth-parser.js
@@ -98,4 +98,4 @@ async function urlToUint8Array(url)
   return new Uint8Array(arrayBuffer);
 }
 
-export {parseDepth}
+export { parseDepth, parseConcatenatedJFIF }

--- a/test/anaglyph-parser.test.js
+++ b/test/anaglyph-parser.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseAnaglyph } from '../parsers/anaglyph-parser/anaglyph-parser.js';
+
+class FakeImage {
+  constructor() {
+    this.width = 1;
+    this.height = 1;
+    this._src = '';
+    this._onload = null;
+  }
+  set src(v) { this._src = v; if (this._onload) setImmediate(this._onload); }
+  get src() { return this._src; }
+  set onload(fn) { this._onload = fn; if (this._src) setImmediate(fn); }
+  get onload() { return this._onload; }
+}
+
+class FakeImageData {
+  constructor(data, width, height) { this.data = data; this.width = width; this.height = height; }
+}
+
+test('parseAnaglyph splits color channels', async () => {
+  const origFetch = global.fetch;
+  const origImage = global.Image;
+  const origDocument = global.document;
+  const origImageData = global.ImageData;
+
+  global.fetch = async () => ({ blob: async () => new Blob() });
+  global.Image = FakeImage;
+  global.ImageData = FakeImageData;
+
+  const pixel = [10, 20, 30, 40];
+  global.document = {
+    createElement: () => ({
+      getContext: () => ({
+        drawImage: () => {},
+        getImageData: () => ({ data: new Uint8ClampedArray(pixel) })
+      })
+    })
+  };
+
+  try {
+    const result = await parseAnaglyph('data:image/jpeg;base64,AA');
+    assert.deepStrictEqual(Array.from(result.leftEye.data), [10,10,10,40]);
+    assert.deepStrictEqual(Array.from(result.rightEye.data), [20,20,20,40]);
+    assert.equal(result.phiLength, 1.02278);
+    assert.equal(result.thetaLength, 0.8838);
+    assert.equal(result.thetaStart, Math.PI / 2 - result.thetaLength / 2);
+  } finally {
+    global.fetch = origFetch;
+    global.Image = origImage;
+    global.document = origDocument;
+    global.ImageData = origImageData;
+  }
+});

--- a/test/depth-parser.test.js
+++ b/test/depth-parser.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseDepth } from '../parsers/depth-parser/depth-parser.js';
+
+// Helper to create a minimal JPEG payload
+function makeJPEG(payload) {
+  const start = [0xff, 0xd8]; // SOI
+  const end = [0xff, 0xd9];   // EOI
+  return new Uint8Array([...start, ...payload, ...end]);
+}
+
+class FakeImage {
+  constructor() {
+    this._src = '';
+    this._onload = null;
+  }
+  set src(v) {
+    this._src = v;
+    if (this._onload) setImmediate(this._onload);
+  }
+  get src() { return this._src; }
+  set onload(fn) {
+    this._onload = fn;
+    if (this._src) setImmediate(fn);
+  }
+  get onload() { return this._onload; }
+}
+
+test('parseDepth extracts embedded depth image', async () => {
+  const OriginalImage = global.Image;
+  global.Image = FakeImage;
+  try {
+    const imgs = [
+      makeJPEG([0]),
+      makeJPEG([1]),
+      makeJPEG([2]),
+      makeJPEG([3]),
+      makeJPEG([4]),
+    ];
+    const concatenated = new Uint8Array(imgs.reduce((arr, i) => [...arr, ...i], []));
+    const url = 'data:image/jpeg;base64,' + Buffer.from(concatenated).toString('base64');
+
+    const result = await parseDepth(url);
+
+    assert.ok(result.depth instanceof FakeImage);
+    assert.strictEqual(result.leftEye, result.rightEye);
+    assert.equal(result.phiLength, 1.02278);
+    assert.equal(result.thetaLength, 0.8838);
+    assert.equal(result.thetaStart, Math.PI / 2 - result.thetaLength / 2);
+  } finally {
+    global.Image = OriginalImage;
+  }
+});

--- a/test/stereo-parser.test.js
+++ b/test/stereo-parser.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseStereo } from '../parsers/stereo-parser/stereo-parser.js';
+
+class FakeImage {
+  constructor() {
+    this.width = 2;
+    this.height = 1;
+    this._src = '';
+    this._onload = null;
+  }
+  set src(v) { this._src = v; if (this._onload) setImmediate(this._onload); }
+  get src() { return this._src; }
+  set onload(fn) { this._onload = fn; if (this._src) setImmediate(fn); }
+  get onload() { return this._onload; }
+}
+
+class FakeImageData {
+  constructor(data, width, height) { this.data = data; this.width = width; this.height = height; }
+}
+
+test('parseStereo rejects when exif parsing fails', async () => {
+  const origImage = global.Image;
+  const origDocument = global.document;
+  const origImageData = global.ImageData;
+  global.Image = FakeImage;
+  global.ImageData = FakeImageData;
+
+  const pixels = [1,2,3,4, 5,6,7,8];
+  function makeCanvas() {
+    return {
+      getContext: () => ({
+        drawImage: () => {},
+        getImageData: (x, y, w, h) => {
+          const arr = [];
+          for (let j = 0; j < h; j++) {
+            for (let i = 0; i < w; i++) {
+              const idx = ((y + j) * 2 + (x + i)) * 4;
+              arr.push(...pixels.slice(idx, idx + 4));
+            }
+          }
+          return { data: new Uint8ClampedArray(arr) };
+        }
+      })
+    };
+  }
+  global.document = { createElement: makeCanvas };
+
+  try {
+    await assert.rejects(
+      parseStereo('data:image/jpeg;base64,AA', { projection: 'equirectangular', angle: 180 })
+    );
+  } finally {
+    global.Image = origImage;
+    global.document = origDocument;
+    global.ImageData = origImageData;
+  }
+});

--- a/test/vr-parser.test.js
+++ b/test/vr-parser.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseVR } from '../parsers/vr-parser/vr-parser.js';
+
+class FakeImage {
+  constructor() {
+    this.width = 1;
+    this.height = 1;
+    this._src = '';
+    this._onload = null;
+  }
+  set src(v) { this._src = v; if (this._onload) setImmediate(this._onload); }
+  get src() { return this._src; }
+  set onload(fn) { this._onload = fn; if (this._src) setImmediate(fn); }
+  get onload() { return this._onload; }
+}
+
+class FakeImageData { constructor(data, w, h){ this.data=data; this.width=w; this.height=h; } }
+
+test('parseVR rejects invalid images', async () => {
+  const origImage = global.Image;
+  const origDocument = global.document;
+  const origImageData = global.ImageData;
+
+  global.Image = FakeImage;
+  global.ImageData = FakeImageData;
+
+  global.document = {
+    createElement: () => ({
+      getContext: () => ({
+        drawImage: () => {},
+        getImageData: () => ({ data: new Uint8ClampedArray([0, 0, 0, 0]) })
+      })
+    })
+  };
+
+  try {
+    await assert.rejects(parseVR('data:image/jpeg;base64,AA'));
+  } finally {
+    global.Image = origImage;
+    global.document = origDocument;
+    global.ImageData = origImageData;
+  }
+});


### PR DESCRIPTION
## Summary
- add unit test for anaglyph parser
- add failing-exif test for stereo parser
- add invalid-input test for VR parser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e434c7aa883329a823cbbe5ae9dc5